### PR TITLE
Adds railtie and rails delivery method for emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,33 @@ Headquarters::Member.all_internal
 
 #### Emails
 
-You can send emails for Group Buddies addresses (Any non-GB addresses will be filtered out)
+You can send emails for Group Buddies addresses (Any non-GB addresses will be filtered out).
+
+`app_name` can be set to be appended to the sender. i.e. `from: hq@groupbuddies.com, app_name: test` will become `hq+test@groupbuddies.com`. This is useful for filtering and labeling.
 
 ```ruby
 Headquarters::Email.send(to: 'mpalhas@groupbuddies.com,zamith@groupbuddies.com', subject: 'custom subject', body: '<b>HTML body</b>', app_name: 'hq')
+```
+
+  When using rails you can use headquarters as the delivery method, and transparently send emails using ActiveMailer as usual:
+
+```ruby
+# config/initializers/mailer.rb
+ActionMailer::Base.delivery_method = :headquarters
+```
+
+Using this method, `app_name` is also available as a header or parameter to the `mail` function
+
+```ruby
+class CustomMailer < ActionMailer::Base
+  # option 1, default header
+  default 'app_name' => 'MyApp'
+
+  def email
+    # option 2, as an argument
+    mail to: 'example@email.com', subjet: 'Subject', app_name: 'MyApp'
+  end
+end
 ```
 
 ## Testing

--- a/lib/headquarters.rb
+++ b/lib/headquarters.rb
@@ -5,6 +5,10 @@ require 'dotenv'
 require 'headquarters/version'
 require 'headquarters/endpoints'
 
+if defined? ::Rails::Railtie
+  require 'headquarters/railtie'
+end
+
 module Headquarters
   API_BASE = 'hq.groupbuddies.com'
   ROOT_PATH = File.dirname(__FILE__)

--- a/lib/headquarters/email.rb
+++ b/lib/headquarters/email.rb
@@ -1,9 +1,33 @@
 module Headquarters
   class Email
-    def self.send(**params)
-      return unless params[:to] && params[:body]
+    FIELDS = %i(to from subject app_name body)
 
+    def self.send(**raw_params)
+      prepare_params(raw_params)
       Request.perform_with_auth(:post, Endpoints::Internal::EMAIL, params)
+    end
+
+    class << self
+      attr_accessor(*FIELDS)
+    end
+
+    def self.params
+      Hash[FIELDS.map do |field|
+        [field, public_send(field)]
+      end.compact]
+    end
+
+    private
+
+    def self.prepare_params(raw_params)
+      @to = raw_params[:to]
+      if @to.is_a? Array
+        @to = @to.join(',')
+      end
+      @from = raw_params[:from]
+      @subject = raw_params[:subject]
+      @app_name = raw_params[:app_name]
+      @body = raw_params[:body]
     end
   end
 end

--- a/lib/headquarters/email.rb
+++ b/lib/headquarters/email.rb
@@ -17,8 +17,6 @@ module Headquarters
       end.compact]
     end
 
-    private
-
     def self.prepare_params(raw_params)
       @to = raw_params[:to]
       if @to.is_a? Array

--- a/lib/headquarters/email/rails_delivery_method.rb
+++ b/lib/headquarters/email/rails_delivery_method.rb
@@ -1,0 +1,32 @@
+require 'headquarters/email'
+
+module Headquarters
+  class Email
+    class RailsDeliveryMethod
+      attr_accessor :options
+
+      def initialize(options = {})
+        self.options = options
+      end
+
+      def deliver(mail)
+        params = {
+          from:     mail.from,
+          to:       mail.to,
+          subject:  mail.subject,
+          body:     mail.body.to_s,
+          app_name: mail.header['app_name'].to_s
+        }
+        require 'pry'
+        binding.pry
+        Headquarters::Email.new(params).send
+      end
+
+      alias_method :deliver!,       :deliver
+      alias_method :deliver_now,    :deliver
+      alias_method :deliver_now!,   :deliver
+      alias_method :deliver_later,  :deliver
+      alias_method :deliver_later!, :deliver
+    end
+  end
+end

--- a/lib/headquarters/email/rails_delivery_method.rb
+++ b/lib/headquarters/email/rails_delivery_method.rb
@@ -17,8 +17,6 @@ module Headquarters
           body:     mail.body.to_s,
           app_name: mail.header['app_name'].to_s
         }
-        require 'pry'
-        binding.pry
         Headquarters::Email.new(params).send
       end
 

--- a/lib/headquarters/railtie.rb
+++ b/lib/headquarters/railtie.rb
@@ -1,0 +1,12 @@
+require 'headquarters/email'
+require 'headquarters/email/rails_delivery_method'
+
+module Headquarters
+  class Railtie < Rails::Railtie
+    initializer 'headquaters.add_delivery_method' do
+      ActiveSupport.on_load :action_mailer do
+        ActionMailer::Base.add_delivery_method :headquarters, Headquarters::Email::RailsDeliveryMethod
+      end
+    end
+  end
+end

--- a/lib/headquarters/request.rb
+++ b/lib/headquarters/request.rb
@@ -6,12 +6,7 @@ module Headquarters
     base_uri Headquarters.api_base
 
     def self.perform_with_auth(http_method, path, params = {}, options = {})
-      options_with_auth = options.merge(
-        basic_auth: {
-          username: ENV['HQ_BASIC_AUTH_USER'] || ENV['BASIC_AUTH_USER'],
-          password: ENV['HQ_BASIC_AUTH_PASS'] || ENV['BASIC_AUTH_PASS']
-        }
-      )
+      options_with_auth = options.merge(basic_auth_info)
       perform(http_method, path, params, options_with_auth)
     end
 
@@ -49,6 +44,30 @@ module Headquarters
 
     def current_time
       Time.now.utc.strftime('%d/%b/%Y %H:%M:%S %Z')
+    end
+
+    def self.basic_auth_info
+      hq_basic_auth_info || deprecated_basic_auth_info
+    end
+
+    def self.hq_basic_auth_info
+      return unless ENV['HQ_BASIC_AUTH_USER']
+      {
+        basic_auth: {
+          username: ENV['HQ_BASIC_AUTH_USER'],
+          password: ENV['HQ_BASIC_AUTH_PASS']
+        }
+      }
+    end
+
+    def self.deprecated_basic_auth_info
+      warn '[DEPRECATED] Using ENV["BASIC_AUTH_USER"] is deprecated. Please use ENV["HQ_BASIC_AUTH_USER"]'
+      {
+        basic_auth: {
+          username: ENV['BASIC_AUTH_USER'],
+          password: ENV['BASIC_AUTH_PASS']
+        }
+      }
     end
   end
 end

--- a/lib/headquarters/request.rb
+++ b/lib/headquarters/request.rb
@@ -8,8 +8,8 @@ module Headquarters
     def self.perform_with_auth(http_method, path, params = {}, options = {})
       options_with_auth = options.merge(
         basic_auth: {
-          username: ENV['BASIC_AUTH_USER'],
-          password: ENV['BASIC_AUTH_PASS']
+          username: ENV['HQ_BASIC_AUTH_USER'] || ENV['BASIC_AUTH_USER'],
+          password: ENV['HQ_BASIC_AUTH_PASS'] || ENV['BASIC_AUTH_PASS']
         }
       )
       perform(http_method, path, params, options_with_auth)

--- a/spec/email_spec.rb
+++ b/spec/email_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+module Headquarters
+  describe Email do
+    context '.send' do
+      it 'makes a new POST request using the correct API endpoint' do
+        allow(Request).to receive(:perform_with_auth)
+        params = { subject: 'fake subject' }
+
+        Email.send(params)
+
+        expect(Request).to have_received(:perform_with_auth).with(:post, Endpoints::Internal::EMAIL, hash_including(params))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allows sending emails via ActionMailer, which is much easier in order to use views and have access to helpers, etc, and makes the integration much more transparent

Right after this, a pull request will also be made on Council, adding email notifications using this feature